### PR TITLE
Fix "Visit Website" link in Feedly

### DIFF
--- a/src/grumpy/server.clj
+++ b/src/grumpy/server.clj
@@ -70,8 +70,8 @@
           (str 
             "\n  <entry>\n"
             "    <title>Ворчание ягнят</title>\n"
-            "    <link rel=\"alternate\" type=\"text/html\" href=\"" grumpy/hostname "/posts/" (:id post) "\" />\n"
-            "    <id>" grumpy/hostname "/posts/" (:id post) "</id>\n"
+            "    <link rel=\"alternate\" type=\"text/html\" href=\"" grumpy/hostname "/post/" (:id post) "\" />\n"
+            "    <id>" grumpy/hostname "/post/" (:id post) "</id>\n"
             "    <published>" (grumpy/format-iso-inst (:created post)) "</published>\n"
             "    <updated>" (grumpy/format-iso-inst (:updated post)) "</updated>\n"
             "    <content type=\"html\"><![CDATA[\n"


### PR DESCRIPTION
You've made typo, mate. I'll cover you.

Fixes that button in feedly: 
![screen shot 2017-09-04 at 13 32 20](https://user-images.githubusercontent.com/486922/30024752-893db0a2-9175-11e7-8fc6-369ec85cf3e2.png)
